### PR TITLE
doctrine/orm 3 compatiblity

### DIFF
--- a/src/IdGenerator/EnumIdGenerator.php
+++ b/src/IdGenerator/EnumIdGenerator.php
@@ -23,7 +23,7 @@ class EnumIdGenerator extends AssignedGenerator
      *
      * @throws EntityMissingAssignedId
      */
-    public function generateId(EntityManagerInterface $em, $entity)
+    public function generateId(EntityManagerInterface $em, $entity): array
     {
         $identifier = parent::generateId($em, $entity);
 


### PR DESCRIPTION
Declaration of VKollin\Doctrine\BackedEnumFields\IdGenerator\EnumIdGenerator::generateId(Doctrine\ORM\EntityManagerInterface $em, $entity) must be compatible with Doctrine\ORM\Id\AssignedGenerator::generateId(Doctrine\ORM\EntityManagerInterface $em, ?object $entity): array